### PR TITLE
Link to /articles/ 404's; Should be /blog/?

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -25,7 +25,7 @@
 </div>
 
 <div id="index" itemprop="mainContentOfPage" itemscope itemtype="http://schema.org/Blog">
-  <h3><a href="{{ site.url}}/articles/">Articles</a></h3>
+  <h3><a href="{{ site.url}}/blog/">Articles</a></h3>
   {% for post in site.posts limit:5 %}    
   <article itemscope itemtype="http://schema.org/BlogPosting" itemprop="blogPost">
     <h2 itemprop="headline"><a href="{{ site.url }}{{ post.url }}" rel="bookmark" title="{{ post.title }}">{{ post.title }}</a></h2>


### PR DESCRIPTION
On your home page, the link to `/articles/` 404's. It probably should be `/blog/` instead, right?
